### PR TITLE
ci(circle): Fix getting version from git tags of current job's HEAD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ aliases:
     run:
       name: Export current version from tag to env variable
       command: |-
-        CURRENT_VERSION="$(git tag -l | sort -V -r | head -1 | sed -E 's/v(.*)/\1/')"
+        CURRENT_VERSION="$(git describe --abbrev=0 --tags | sed -E 's/v(.*)/\1/')"
         if [ "" == "$CURRENT_VERSION" ]; then CURRENT_VERSION="0.0.0"; fi
         echo "CURRENT_VERSION=$CURRENT_VERSION"
         echo "export CURRENT_VERSION='$CURRENT_VERSION'" >> $BASH_ENV


### PR DESCRIPTION
Command `git tag -l` list all available tags. We need only latest tag in current revision.